### PR TITLE
Bp 272 filter columns

### DIFF
--- a/src/ProductView/EventTable/EventTable.js
+++ b/src/ProductView/EventTable/EventTable.js
@@ -15,13 +15,13 @@ class EventTable extends Component {
         if (!currentFilter.value) {
             return true;
         }
-        let headersToBeSearched = this.props.header;
+        let columnsToBeSearched = this.props.header;
         if(currentFilter.column) {
-          headersToBeSearched = headersToBeSearched.filter((eventPropertyKey) => {
+          columnsToBeSearched = columnsToBeSearched.filter((eventPropertyKey) => {
             return this.doesContain(eventPropertyKey.name, currentFilter.column);
           });
         }
-        return headersToBeSearched.some((eventPropertyKey) => {
+        return columnsToBeSearched.some((eventPropertyKey) => {
             return this.doesContain(currentEvent[eventPropertyKey.name], currentFilter.value);
         });
     }

--- a/src/ProductView/EventTable/EventTable.js
+++ b/src/ProductView/EventTable/EventTable.js
@@ -15,11 +15,19 @@ class EventTable extends Component {
         if (!currentFilter.value) {
             return true;
         }
-        return this.props.header.some((eventPropertyKey) => {
-            const eventPropertyValue = currentEvent[eventPropertyKey.name].toString().toLowerCase();
-            const searchQuery = currentFilter.value.toString().toLowerCase();
-            return (eventPropertyValue.indexOf(searchQuery) > -1);
+        let headersToBeSearched = this.props.header;
+        if(currentFilter.column) {
+          headersToBeSearched = headersToBeSearched.filter((eventPropertyKey) => {
+            return this.doesContain(eventPropertyKey.name, currentFilter.column);
+          });
+        }
+        return headersToBeSearched.some((eventPropertyKey) => {
+            return this.doesContain(currentEvent[eventPropertyKey.name], currentFilter.value);
         });
+    }
+
+    doesContain(baseValue, subValue) {
+      return (baseValue.toString().toLowerCase().indexOf(subValue.toString().toLowerCase()) > -1);
     }
 
     render() {

--- a/src/ProductView/ProductView.js
+++ b/src/ProductView/ProductView.js
@@ -12,7 +12,7 @@ class ProductView extends Component {
         super(props);
         this.prodId = parseInt(this.props.params.productID, 10);
         this.state = {
-            filter: [{id: 'filter-0', value: ''}],
+            filter: [{id: 'filter-0', value: '', column: null}],
             lastFilterId: 0,
             product: null,
             eventTypes: null,
@@ -103,12 +103,20 @@ class ProductView extends Component {
 
     onChangeFilterInput(currentFilterId, value) {
         const updatedFilters = this.state.filter;
-        updatedFilters[currentFilterId].value = value;
+        const separatorPosition = value.indexOf(":");
+        if(separatorPosition > 0 && separatorPosition < value.length - 1) {
+          updatedFilters[currentFilterId].column = value.substr(0, separatorPosition);
+          updatedFilters[currentFilterId].value = value.substr(separatorPosition+1);
+        }
+        else {
+          updatedFilters[currentFilterId].column = null;
+          updatedFilters[currentFilterId].value = value;
+        }
 
         if(currentFilterId === this.state.lastFilterId) {
             const newFilterId = this.state.lastFilterId + 1;
-            const newFilter = {id: `filter-${newFilterId}`, value: ''};
-            this.setState({ 
+            const newFilter = {id: `filter-${newFilterId}`, value: '', column: null};
+            this.setState({
                 filter: updatedFilters.concat([newFilter]),
                 lastFilterId: newFilterId
             });

--- a/src/__tests__/ProductView/EventTable.js
+++ b/src/__tests__/ProductView/EventTable.js
@@ -16,3 +16,9 @@ test("Rendering of EventTable", () => {
     const tree = component.toJSON();
     expect(tree).toMatchSnapshot();
 });
+
+test("Inclusion of two values", () => {
+  expect(instance.doesContain("baseString", "string")).toBeTruthy();
+  expect(instance.doesContain([123], "12")).toBeTruthy();
+  expect(instance.doesContain("baseString", "strr")).toBeFalsy();
+});

--- a/src/__tests__/ProductView/EventTable.js
+++ b/src/__tests__/ProductView/EventTable.js
@@ -6,7 +6,7 @@ import TestEventTypes from './../testData/eventTypes';
 let instance;
 
 test("Rendering of EventTable", () => {
-    const mockFilter = {id: 'mock-filter', value: '200'};
+    const mockFilter = {id: 'mock-filter', value: '4', column: 'errorcode'};
     const component = renderer.create(
         <EventTable ref={(child) => {instance = child}}
                     header={TestEventTypes.EVENTTYPES[0].attributes}

--- a/src/__tests__/ProductView/ProductView.js
+++ b/src/__tests__/ProductView/ProductView.js
@@ -46,7 +46,9 @@ test('Update Event data', () => {
 });
 
 test('Successful filtering', () => {
-   instance.onChangeFilterInput(0, 'Product');
+    instance.onChangeFilterInput(0, 'Product');
+    expect(instance.state.filter[0].value).toBe("Product");
+    expect(instance.state.filter[0].column).toBeNull();
     const tree = component.toJSON();
     expect(tree).toMatchSnapshot();
 });
@@ -58,7 +60,9 @@ test('Changing active Tab', () => {
 });
 
 test('Change filter', () => {
-    instance.onChangeFilterInput(0, 'Query without result');
+    instance.onChangeFilterInput(0, 'columnName:Product');
+    expect(instance.state.filter[0].value).toBe("Product");
+    expect(instance.state.filter[0].column).toBe("columnName");
     const tree = component.toJSON();
     expect(tree).toMatchSnapshot();
 });

--- a/src/__tests__/ProductView/__snapshots__/EventTable.js.snap
+++ b/src/__tests__/ProductView/__snapshots__/EventTable.js.snap
@@ -29,7 +29,32 @@ exports[`test Rendering of EventTable 1`] = `
         </th>
       </tr>
     </thead>
-    <tbody />
+    <tbody>
+      <tr>
+        <th
+          scope="row">
+          0
+        </th>
+        <td>
+          404
+        </td>
+        <td>
+          Product not found.
+        </td>
+        <td>
+          Search for it.
+        </td>
+        <td>
+          666
+        </td>
+        <td>
+          Not known.
+        </td>
+        <td>
+          0.0.4.alpha
+        </td>
+      </tr>
+    </tbody>
   </table>
 </div>
 `;

--- a/src/__tests__/ProductView/__snapshots__/ProductView.js.snap
+++ b/src/__tests__/ProductView/__snapshots__/ProductView.js.snap
@@ -458,6 +458,54 @@ exports[`test Changing active Tab 1`] = `
               0.0.4.alpha
             </td>
           </tr>
+          <tr>
+            <th
+              scope="row">
+              1
+            </th>
+            <td>
+              123
+            </td>
+            <td>
+              Product not found.
+            </td>
+            <td>
+              Search for it.
+            </td>
+            <td>
+              444
+            </td>
+            <td>
+              Hamburg
+            </td>
+            <td>
+              0.0.7
+            </td>
+          </tr>
+          <tr>
+            <th
+              scope="row">
+              2
+            </th>
+            <td>
+              987
+            </td>
+            <td>
+              Product not found.
+            </td>
+            <td>
+              Replace machine
+            </td>
+            <td>
+              333
+            </td>
+            <td>
+              Berlin
+            </td>
+            <td>
+              0.1.0
+            </td>
+          </tr>
         </tbody>
       </table>
     </div>

--- a/src/__tests__/testData/events.js
+++ b/src/__tests__/testData/events.js
@@ -5,6 +5,22 @@ const events = [{
     DeviceID:                   666,
     DeviceLocation:             "Not known.",
     SoftwareVersion:            "0.0.4.alpha"
+},
+{
+    ErrorCode:                  123,
+    ErrorDescription:           "Product not found.",
+    PossibleFix:                "Search for it.",
+    DeviceID:                   444,
+    DeviceLocation:             "Hamburg",
+    SoftwareVersion:            "0.0.7"
+},
+{
+    ErrorCode:                  987,
+    ErrorDescription:           "Product not found.",
+    PossibleFix:                "Replace machine",
+    DeviceID:                   333,
+    DeviceLocation:             "Berlin",
+    SoftwareVersion:            "0.1.0"
 }];
 
 export default {


### PR DESCRIPTION
Add the possibility to specify a column in which the given value should be searched in.
You now may use "columnname:search value" or even "colu:search value" to match "search value" in every column having "colu" in header.