### PR TITLE
BP 358: Clearing Query Interface

### DIFF
--- a/src/ProductView/TabBar/QueryInterface/QueryInterface.js
+++ b/src/ProductView/TabBar/QueryInterface/QueryInterface.js
@@ -6,7 +6,7 @@ import {argosConfig} from './../../../config/argosConfig.js';
 class QueryInterface extends Component {
     constructor(props) {
         super(props);
-        this.setDefaultState();
+        this.state = QueryInterface.getDefaultState();
         this.nextAttributeId = this.state.eventTypeAttributes.length;
         this.handleChangeEventTypeName = this.handleChangeEventTypeName.bind(this);
         this.handleChangeAttributeName = this.handleChangeAttributeName.bind(this);
@@ -18,7 +18,11 @@ class QueryInterface extends Component {
     }
 
     setDefaultState() {
-        this.state = {
+        this.setState(QueryInterface.getDefaultState());
+    }
+
+    static getDefaultState() {
+        return ({
             eventTypeName: '',
             eventTypeAttributes: [
                 {
@@ -57,11 +61,16 @@ class QueryInterface extends Component {
             validationClasses: '',
             modalLoading: false,
             modalIsAbleToSave: false
-        };
+        });
     }
 
     componentDidMount() {
-        $(document).ready(function(){ $("#new-complex-eventtype").tooltip(); });
+        $(document).ready(function(){
+            $("#new-complex-eventtype").tooltip();
+            $("#query-interface-modal").on('hidden.bs.modal', function() {
+                this.setDefaultState();
+            }.bind(this));
+        }.bind(this));
     }
 
     addEmptyAttribute(attributes) {
@@ -141,7 +150,6 @@ class QueryInterface extends Component {
     /* istanbul ignore next */
     handleSaveQuerySuccess() {
         $('#query-interface-modal').modal('hide');
-        this.setDefaultState();
     }
 
     handleSaveQueryError(error) {

--- a/src/ProductView/TabBar/QueryInterface/QueryInterface.js
+++ b/src/ProductView/TabBar/QueryInterface/QueryInterface.js
@@ -6,6 +6,18 @@ import {argosConfig} from './../../../config/argosConfig.js';
 class QueryInterface extends Component {
     constructor(props) {
         super(props);
+        this.setDefaultState();
+        this.nextAttributeId = this.state.eventTypeAttributes.length;
+        this.handleChangeEventTypeName = this.handleChangeEventTypeName.bind(this);
+        this.handleChangeAttributeName = this.handleChangeAttributeName.bind(this);
+        this.handleChangeAttributeType = this.handleChangeAttributeType.bind(this);
+        this.handleChangeQuery = this.handleChangeQuery.bind(this);
+        this.handleSaveQuery = this.handleSaveQuery.bind(this);
+        this.handleSaveQuerySuccess = this.handleSaveQuerySuccess.bind(this);
+        this.handleSaveQueryError = this.handleSaveQueryError.bind(this);
+    }
+
+    setDefaultState() {
         this.state = {
             eventTypeName: '',
             eventTypeAttributes: [
@@ -46,14 +58,6 @@ class QueryInterface extends Component {
             modalLoading: false,
             modalIsAbleToSave: false
         };
-        this.nextAttributeId = this.state.eventTypeAttributes.length;
-        this.handleChangeEventTypeName = this.handleChangeEventTypeName.bind(this);
-        this.handleChangeAttributeName = this.handleChangeAttributeName.bind(this);
-        this.handleChangeAttributeType = this.handleChangeAttributeType.bind(this);
-        this.handleChangeQuery = this.handleChangeQuery.bind(this);
-        this.handleSaveQuery = this.handleSaveQuery.bind(this);
-        this.handleSaveQuerySuccess = this.handleSaveQuerySuccess.bind(this);
-        this.handleSaveQueryError = this.handleSaveQueryError.bind(this);
     }
 
     componentDidMount() {
@@ -70,8 +74,6 @@ class QueryInterface extends Component {
         this.nextAttributeId = this.nextAttributeId + 1;
         return attributes;
     }
-
-
 
     getEventTypeAttribute(id) {
         return this.state.eventTypeAttributes.find((attribute) => {
@@ -139,7 +141,7 @@ class QueryInterface extends Component {
     /* istanbul ignore next */
     handleSaveQuerySuccess() {
         $('#query-interface-modal').modal('hide');
-        this.setState({ modalLoading: false });
+        this.setDefaultState();
     }
 
     handleSaveQueryError(error) {

--- a/src/ProductView/TabBar/QueryInterface/QueryInterface.js
+++ b/src/ProductView/TabBar/QueryInterface/QueryInterface.js
@@ -64,6 +64,7 @@ class QueryInterface extends Component {
         });
     }
 
+    /* istanbul ignore next */
     componentDidMount() {
         $(document).ready(function(){
             $("#new-complex-eventtype").tooltip();

--- a/src/__tests__/ProductView/QueryInterface.js
+++ b/src/__tests__/ProductView/QueryInterface.js
@@ -74,3 +74,9 @@ test('Form validation of event queries', () => {
     instance.eventQueryFormValidation('test');
     expect(instance.state.validationClasses).toBe('');
 });
+
+test('Set default state', () => {
+    instance.setState({modalIsAbleToSave: true});
+    instance.setDefaultState();
+    expect(instance.state.modalIsAbleToSave).toBe(false);
+});

--- a/src/__tests__/ProductView/__snapshots__/ProductView.js.snap
+++ b/src/__tests__/ProductView/__snapshots__/ProductView.js.snap
@@ -535,7 +535,7 @@ exports[`test Change filter 1`] = `
                               onChange={[Function]}
                               rows="8"
                               type="text"
-                              value="INSERT INTO TestErrorEvents SELECT timestamp, productId, productFamilyId FROM FeedbackData" />
+                              value="INSERT INTO TestErrorEvents SELECT timestamp, productId, productFamilyId, codingPlugId, codingPlugSoftwareVersion FROM FeedbackData" />
                             
                           </div>
                         </div>
@@ -1098,7 +1098,7 @@ exports[`test Changing active Tab 1`] = `
                               onChange={[Function]}
                               rows="8"
                               type="text"
-                              value="INSERT INTO TestErrorEvents SELECT timestamp, productId, productFamilyId FROM FeedbackData" />
+                              value="INSERT INTO TestErrorEvents SELECT timestamp, productId, productFamilyId, codingPlugId, codingPlugSoftwareVersion FROM FeedbackData" />
                             
                           </div>
                         </div>
@@ -1858,7 +1858,7 @@ exports[`test Remove last filter 1`] = `
                               onChange={[Function]}
                               rows="8"
                               type="text"
-                              value="INSERT INTO TestErrorEvents SELECT timestamp, productId, productFamilyId FROM FeedbackData" />
+                              value="INSERT INTO TestErrorEvents SELECT timestamp, productId, productFamilyId, codingPlugId, codingPlugSoftwareVersion FROM FeedbackData" />
                             
                           </div>
                         </div>
@@ -2421,7 +2421,7 @@ exports[`test Rendering of ProductView 1`] = `
                               onChange={[Function]}
                               rows="8"
                               type="text"
-                              value="INSERT INTO TestErrorEvents SELECT timestamp, productId, productFamilyId FROM FeedbackData" />
+                              value="INSERT INTO TestErrorEvents SELECT timestamp, productId, productFamilyId, codingPlugId, codingPlugSoftwareVersion FROM FeedbackData" />
                             
                           </div>
                         </div>
@@ -3006,7 +3006,7 @@ exports[`test Successful filtering 1`] = `
                               onChange={[Function]}
                               rows="8"
                               type="text"
-                              value="INSERT INTO TestErrorEvents SELECT timestamp, productId, productFamilyId FROM FeedbackData" />
+                              value="INSERT INTO TestErrorEvents SELECT timestamp, productId, productFamilyId, codingPlugId, codingPlugSoftwareVersion FROM FeedbackData" />
                             
                           </div>
                         </div>

--- a/src/__tests__/ProductView/__snapshots__/QueryInterface.js.snap
+++ b/src/__tests__/ProductView/__snapshots__/QueryInterface.js.snap
@@ -261,7 +261,7 @@ exports[`test Handling change query 1`] = `
               onChange={[Function]}
               rows="8"
               type="text"
-              value="INSERT INTO TestErrorEvents SELECT timestamp, productId, productFamilyId FROM FeedbackData" />
+              value="INSERT INTO TestErrorEvents SELECT timestamp, productId, productFamilyId, codingPlugId, codingPlugSoftwareVersion FROM FeedbackData" />
             
           </div>
         </div>
@@ -831,7 +831,7 @@ exports[`test Handling save query failure 1`] = `
               onChange={[Function]}
               rows="8"
               type="text"
-              value="INSERT INTO TestErrorEvents SELECT timestamp, productId, productFamilyId FROM FeedbackData" />
+              value="INSERT INTO TestErrorEvents SELECT timestamp, productId, productFamilyId, codingPlugId, codingPlugSoftwareVersion FROM FeedbackData" />
             
           </div>
         </div>

--- a/src/config/argosConfig_template.js
+++ b/src/config/argosConfig_template.js
@@ -25,7 +25,7 @@ export const argosConfig = {
     errorRemainingDependencies:     'You can not delete this Event-Type, because of existing dependencies',
     messageSuccessEventTypeCreation:'EventType sucessfully created.',
     createEventTypeDefaultQuery:    'INSERT INTO TestErrorEvents SELECT timestamp, productId, ' +
-                                    'productFamilyId FROM FeedbackData',
+                                    'productFamilyId, codingPlugId, codingPlugSoftwareVersionu FROM FeedbackData',
     formValidationNoEmptyMessage:   'This field can\'t be empty.',
     runningStateName:               'running',
     warningStateName:               'warning',

--- a/src/config/argosConfig_template.js
+++ b/src/config/argosConfig_template.js
@@ -25,7 +25,7 @@ export const argosConfig = {
     errorRemainingDependencies:     'You can not delete this Event-Type, because of existing dependencies',
     messageSuccessEventTypeCreation:'EventType sucessfully created.',
     createEventTypeDefaultQuery:    'INSERT INTO TestErrorEvents SELECT timestamp, productId, ' +
-                                    'productFamilyId, codingPlugId, codingPlugSoftwareVersionu FROM FeedbackData',
+                                    'productFamilyId, codingPlugId, codingPlugSoftwareVersion FROM FeedbackData',
     formValidationNoEmptyMessage:   'This field can\'t be empty.',
     runningStateName:               'running',
     warningStateName:               'warning',


### PR DESCRIPTION
The query interface for new event types is now reset to the default values after successful saving. 