### PR TITLE
Hotfix for #PR133

### DIFF
--- a/src/DetailView/DetailView.js
+++ b/src/DetailView/DetailView.js
@@ -142,7 +142,7 @@ class DetailView extends ConnectionComponent {
 	}
 
 	getEventTable() {
-		if (!this.props.eventTypeAttributes || !this.props.events || this.state.filteredEvents.length < 1) {
+		if (!this.props.eventTypeAttributes || !this.props.events) {
 			return "";
 		}
 		const allFetches = PromiseState.all([this.props.eventTypeAttributes, this.props.events]);
@@ -160,7 +160,7 @@ class DetailView extends ConnectionComponent {
 	}
 
 	eventTypeAttributesPending() {
-		if (!this.props.eventTypeAttributes || this.state.filteredEvents.length < 1) {
+		if (!this.props.eventTypeAttributes) {
 			return <div />;
 		}
 		const eventTypeAttributeConnection = super.render(this.props.eventTypeAttributes);
@@ -174,6 +174,9 @@ class DetailView extends ConnectionComponent {
 	}
 
 	getEventDiagram() {
+		if (this.state.filteredEvents.length < 1) {
+			return <div />;
+		}
 		const eventTypeAttributesPending = this.eventTypeAttributesPending();
 		if (eventTypeAttributesPending) {
 			return eventTypeAttributesPending;

--- a/src/DetailView/EventDiagram.js
+++ b/src/DetailView/EventDiagram.js
@@ -11,6 +11,14 @@ class EventDiagram extends Component {
 		this.diagramId = "eventDiagram";
 	}
 
+	componentWillReceiveProps(props) {
+		this.buildChartDataset(props);
+	}
+
+	componentDidMount() {
+		this.buildChartDataset(this.props);
+	}
+
 	static getDiagramLayout(eventCounter) {
 		return {
 			yaxis: {
@@ -40,10 +48,6 @@ class EventDiagram extends Component {
 			traceData.fillcolor = statusColor + opacityFactor;
 		}
 		return [traceData];
-	}
-
-	componentWillReceiveProps(props) {
-		this.buildChartDataset(props);
 	}
 
 	buildChartDataset(props) {


### PR DESCRIPTION
#133 introduced an error:
When setting filters resulting in an empty event set, not only the diagram was hidden but the event table including the filter bar were gone too. Quite uncomfortable if you want to remove this filter.

Now, only the diagram should hide, when there is an empty event set.